### PR TITLE
Use Server struct to address gosec G114

### DIFF
--- a/assets/pora/server.go
+++ b/assets/pora/server.go
@@ -30,9 +30,12 @@ func main() {
 	errCh := make(chan error)
 
 	for _, port := range portArray {
-		println(port)
 		go func(port string) {
-			errCh <- http.ListenAndServe(":"+port, nil)
+			server := &http.Server{
+				Addr:    fmt.Sprintf(":%s", port),
+				Handler: nil,
+			}
+			errCh <- server.ListenAndServe()
 		}(port)
 	}
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Use `Server` struct, which allows setting a timeout, to address gosec G114


Backward Compatibility
---------------
Breaking Change? **No**
