### PR TITLE
Resolve unchecked int overflow case

### DIFF
--- a/assets/pora/server.go
+++ b/assets/pora/server.go
@@ -221,7 +221,7 @@ func chmodFile(res http.ResponseWriter, req *http.Request) {
 		// #nosec - ignore errors writing http responses to avoid spamming logs in the event of a DoS
 		res.Write([]byte(err.Error()))
 	}
-	err = os.Chmod(mountPointPath, os.FileMode(uint(parsedMode)))
+	err = os.Chmod(mountPointPath, os.FileMode(parsedMode))
 	if err != nil {
 		res.WriteHeader(http.StatusForbidden)
 		// #nosec - ignore errors writing http responses to avoid spamming logs in the event of a DoS


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
parsedMode was created by strconv.ParseUint() specifying a size of 32 bits for the number, so checks happened there. However this gets flagged because we took an already-checked uint32, made it uint, then cast it back down to uint32 inside FileMode(). Removing the recast makes all of this go away


Backward Compatibility
---------------
Breaking Change? no