### PR TITLE
remove unnneeded global rand.Seed logic

### DIFF
--- a/assets/pora/server.go
+++ b/assets/pora/server.go
@@ -262,13 +262,7 @@ func env(res http.ResponseWriter, req *http.Request) {
 	}
 }
 
-var isSeeded = false
-
 func randomString(n int) string {
-	if !isSeeded {
-		rand.Seed(time.Now().UnixNano())
-		isSeeded = true
-	}
 	runes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 	b := make([]rune, n)


### PR DESCRIPTION
since go 1.20 rand has been automatically seeded

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Calling rand.Seed globally is no longer needed. Since go 1.20 rand has been automatically seeded. go 1.20 was released in Feb 2022 and is no longer supported. See here for more details. https://pkg.go.dev/math/rand@go1.20#Seed


Backward Compatibility
---------------
Breaking Change? No